### PR TITLE
docs: comment out static storybook link

### DIFF
--- a/packages/apps/docsite/content/docs/showcase.md
+++ b/packages/apps/docsite/content/docs/showcase.md
@@ -8,4 +8,6 @@ order: 3
 
 The [Embeddings Explorer](/embeddings-explorer) application is a visual analytic used to explore graph-based embeddings. This was our initial use-case for component-based visual analytics.
 
+<!--
 The [Storybook](/storybook) contains a set of examples for individual components.
+-->


### PR DESCRIPTION
The static storybook link is broken in prod, presumably because we haven't set a root url or something in storybook. Until we figure that out, this just removes the reference from the docsite